### PR TITLE
Fix deprecation warning on GNOME Shell 3.34

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -132,7 +132,9 @@ function init()
 
 function enable()
 {
-    Main.panel.actor.get_children().forEach(
+    let panelActor = Main.panel instanceof Clutter.Actor ? Main.panel : Main.panel.actor;
+
+    panelActor.get_children().forEach(
         function(actor)
         {
             signalConnections.push({

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
 	"name": "Remove Dropdown Arrows",
 	"description": "Removes the dropdown arrows which were introduced in Gnome 3.10 from the App Menu, System Menu, Input Menu, Access Menu, Places Menu, Applications Menu and any other extension that wants to add dropdown arrows.",
 	"url": "http://github.com/mpdeimos/gnome-shell-remove-dropdown-arrows",
-	"shell-version": ["3.12","3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30"]
+	"shell-version": ["3.12","3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32", "3.34"]
 }


### PR DESCRIPTION
The extension works fine with 3.34, but there is this warning:
```
Remove Dropdown Arrows-Message: 12:37:27.314: Usage of object.actor is deprecated for Panel
get@resource:///org/gnome/shell/ui/environment.js:235:29
enable@/home/kamil/.local/share/gnome-shell/extensions/remove-dropdown-arrows@mpdeimos.com/extension.js:137:9
_callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:130:13
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:263:21
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:477:13
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:17
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:456:9
_enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:486:13
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:517:13
init@resource:///org/gnome/shell/ui/extensionSystem.js:31:9
_initializeUI@resource:///org/gnome/shell/ui/main.js:239:5
start@resource:///org/gnome/shell/ui/main.js:139:5
@<main>:1:31
```